### PR TITLE
feat: improve overall image layout

### DIFF
--- a/pages/events/index.jsx
+++ b/pages/events/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Link from "next/link";
 
-import { Card, Grid } from "@material-ui/core";
+import { Box, Card, Grid } from "@material-ui/core";
 
 import consts from "../../consts.json";
 import AbstractList from "../../components/common/listPage.tsx";
@@ -51,11 +51,18 @@ class DjEventsListPage extends AbstractList {
                         <Grid container>
                             <Grid item xs={0} sm={1}></Grid>
                             <Grid item xs={12} sm={5}>
-                                <SafeImageLoader
-                                    src={this.getIllustUrl(event)}
-                                    alt={event.Id}
-                                    className={this.classes.bannerIcon}
-                                />
+                                <Box
+                                    display="flex"
+                                    width="100%"
+                                    height="100px"
+                                    justifyContent="center"
+                                >
+                                    <SafeImageLoader
+                                        src={this.getIllustUrl(event)}
+                                        alt={event.Id}
+                                        className={this.classes.responsiveIcon}
+                                    />
+                                </Box>
                             </Grid>
                             <Grid item xs={0} sm={1}></Grid>
                             <Grid item xs={12} sm={5}>

--- a/pages/gacha/index.jsx
+++ b/pages/gacha/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Link from 'next/link';
 
-import { Card, Grid } from '@material-ui/core';
+import { Box, Card, Grid } from '@material-ui/core';
 
 import consts from '../../consts.json';
 import AbstractList from '../../components/common/listPage.tsx';
@@ -62,12 +62,19 @@ class DjGachaListPage extends AbstractList {
                     <Grid container>
                         <Grid item xs={0} sm={1}></Grid>
                         <Grid item xs={12} sm={5}>
-                            <SafeImageLoader 
-                                src={this.getIllustUrl(gacha)} 
-                                alt={gacha.Id} 
-                                className={this.classes.bannerIcon} 
-                                alternativeUrl={this.getIllustUrl2(gacha)}
-                            />
+                            <Box
+                                display="flex"
+                                width="100%"
+                                height="100px"
+                                justifyContent="center"
+                            >
+                                <SafeImageLoader 
+                                    src={this.getIllustUrl(gacha)} 
+                                    alt={gacha.Id} 
+                                    className={this.classes.responsiveIcon} 
+                                    alternativeUrl={this.getIllustUrl2(gacha)}
+                                />
+                            </Box>
                         </Grid>
                         <Grid item xs={0} sm={1}></Grid>
                         <Grid item xs={12} sm={5}>

--- a/pages/musics/index.jsx
+++ b/pages/musics/index.jsx
@@ -87,12 +87,13 @@ const MusicCardListView = ({ music, unit, charts }) => {
                             display="flex"
                             justifyContent="center"
                             alignItems="stretch"
-                            maxWidth="150px"
+                            width="150px"
+                            height="150px"
                             marginRight="10px"
+                            flexShrink="0"
                         >
                             <SafeImageLoader
                                 src={getIllustUrl(music)}
-                                style={{ width: "100%", height: "auto" }}
                                 alt={music.Id}
                             />
                         </Box>

--- a/pages/musics/index.jsx
+++ b/pages/musics/index.jsx
@@ -95,6 +95,9 @@ const MusicCardListView = ({ music, unit, charts }) => {
                             <SafeImageLoader
                                 src={getIllustUrl(music)}
                                 alt={music.Id}
+                                style={{
+                                    width: "100%"
+                                }}
                             />
                         </Box>
                         <Box width="100%">

--- a/styles/list.module.css
+++ b/styles/list.module.css
@@ -7,14 +7,8 @@
     width: 100%;
 }
 
-.musicIcon {
-    max-width: 150px;
-    width: 100%;
-}
-
-.bannerIcon {
-    width: 100%;
-    max-width: 300px;
+.responsiveIcon {
+    object-fit: contain;
 }
 
 


### PR DESCRIPTION
This PR mainly aims at:
* Avoid sudden viewport change due to card height change on image loading (by giving a explicit height value to the box)
* Avoid sudden album art width change on `/music` (by `flex-shrink: 0`)
* Layout the banner images at the center, vertically (by `object-fit: contain`) and horizontally (by `justify-content: center`)