### PR TITLE
Get member name correctly displayed

### DIFF
--- a/pages/members/[id].jsx
+++ b/pages/members/[id].jsx
@@ -97,7 +97,10 @@ class DjMemberEntryPage extends React.Component {
     const unit = this.state.unit;
     const lang = strings.getLanguage();
 
-    const localName = strings.getString(`CHR__${chara.FullNameEnglish}`)
+    const localName = strings.getString(`CHR__${member.FullNameEnglish}`,
+                          strings.getString(`OUTSIDE_CHR__${member.FullName}`,
+                              member.FullName)
+                      )
 
     return (
       <div>

--- a/pages/members/[id].jsx
+++ b/pages/members/[id].jsx
@@ -97,9 +97,9 @@ class DjMemberEntryPage extends React.Component {
     const unit = this.state.unit;
     const lang = strings.getLanguage();
 
-    const localName = strings.getString(`CHR__${member.FullNameEnglish}`,
-                          strings.getString(`OUTSIDE_CHR__${member.FullName}`,
-                              member.FullName)
+    const localName = strings.getString(`CHR__${chara.FullNameEnglish}`,
+                          strings.getString(`OUTSIDE_CHR__${chara.FullName}`,
+                              chara.FullName)
                       )
 
     return (


### PR DESCRIPTION
tl;dr it's broken for guest characters now:

![image](https://user-images.githubusercontent.com/19144373/122588942-4072cc80-d092-11eb-9297-a036fddb9a87.png)

I think it is a missed point for the last l10n update...